### PR TITLE
Comma removed, it looked like tuple

### DIFF
--- a/pyvkontakte/auth.py
+++ b/pyvkontakte/auth.py
@@ -30,7 +30,7 @@ def _build_login_url(client_id, scope):
         'redirect_uri': 'http://oauth.vk.com/blank.html',
         'response_type': 'token',
         'client_id': client_id,
-        'scope': scope,
+        'scope': scope
     }
     prepared_request = requests.PreparedRequest()
     prepared_request.prepare('GET', url=base_url, params=query)


### PR DESCRIPTION
> > > a = 3, 
> > > a
> > > (3,)# tuple
> > > In dict it's autocorrected:
> > > a = {
> > > ...  'foo' : 5,
> > > ...  'bar' : 3,
> > > ... }
> > > a
> > > {'foo': 5, 'bar': 3}
> > > But it looks bad.
